### PR TITLE
clarify financial quarters where dues are prorated

### DIFF
--- a/bylaws.txt
+++ b/bylaws.txt
@@ -20,6 +20,7 @@
 3.4.4.1. Endeavor to better the cast in all actions.
 3.4.4.2. Pay dues to the cast of $20 per calendar year, to be collected by the Financial Secretary each January, or if the member is not at any cast function in January, at the earliest cast function at which the member is present.
 3.4.4.2.1. Dues shall be prorated for all new cast members who join after January in a given year at $5 per quarter.
+3.4.4.2.1.1. The quarters are: [jan-mar][apr-jun][jul-sep][oct-dec]
 3.4.4.3. Make a good faith effort to attend as many shows as possible.
 3.4.4.4. Participate in membership meetings.(see Article 6)
 3.4.4.4.1. All active cast members must attend at least one membership meeting per year. Inactive members may choose to attend these meetings. 


### PR DESCRIPTION
Our "Rocky Year" ends in October, which makes our "Rocky" Quarter System:
1. [Nov-Jan]  
2. [Feb-April]  
3. [May-Jul]  
4. [Aug-Oct]  

Which makes sense, considering the membership meetings are in nov, feb, may, and aug.

> **3.4.4.2.** Pay dues to the cast of $20 per calendar year, to be collected by the Financial Secretary each January, or if the member is not at any cast function in January, at the earliest cast function at which the member is present.

> **3.4.4.2.1.** Dues shall be prorated for all new cast members who join after January in a given year at $5 per quarter.

Either the original intent was to collect dues in the last month of the first quarter, or there's a discrepancy between our cast's "rocky months" and the "quarter system" *proposed* here, establishing the first month as Jan w/ the collection of dues?
