### PR TITLE
Disciplining a Director and when to recuse 

### DIFF
--- a/bylaws.txt
+++ b/bylaws.txt
@@ -174,6 +174,7 @@
 7.2.2.1.1.2.1. The ad hoc committee will consist of two members chosen by the Directors and one member chosen by the member in question. 
 7.2.2.1.1.2.1.1. The member in question will be invited to attend and speak at meetings by the ad hoc committee.
 7.2.2.1.1.2.1.2. The member in question may decline to nominate a representative to the ad hoc committee.
+7.2.2.1.1.2.1.3. If the member in question is one of the directors, or a director is a party to the complaint or grievance, the director shall not make decisions on the disciplinary committee's formation, excepting the choice of their own advocate where they are the member in question. 
 7.2.2.1.1.3. This committee’s mandate is not to punish the member, but to discuss and implement changes they deem necessary to maintain the quality of the show and the cast environment.This may include the member no longer being assigned responsibilities that they are not meeting. 
 7.2.3. In severe cases that create a hostile environment, or involve a threat to either the audience or cast members, or puts in jeopardy the continuance of the show or cast, the Directors shall immediately convene an ad hoc committee as described in 7.2.2.1.1.2 to address the issue and deal with the cast member that is causing the problem.
 7.2.3.1. Efforts shall be made to work collaboratively, but if a reasonable accommodation cannot be reached, the committee may recommend that the member be removed from cast.


### PR DESCRIPTION
This amendment was *drafted* and **passed** at the [2019NOV16 Membership Meeting](#).

It is meant to address situations where a director may be disciplined, or may be a party to a complaint or grievance.

**CURRENTLY:** if a director is the "member in question", they get to choose an advocate, and are 1/2 of the people that choose the other two members, giving them influence on 3/3 committee members.

If a director is a complainant or a party to a grievance,  they are one of two people that get to choose 2/3 of the committee members addressing the member in question.

**AFTER AMENDMENT:** if only one director is a party to a complaint or grievance, that leaves the other able to make decisions about the formation of the committee. Where both must recuse or are a party to the process already, the responsibility would fall to the next decision making body, the *Cast Council*.